### PR TITLE
Mobile zoom controls, landscape guard, and iOS safe-area fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,29 @@ Photos are NOT included in the static export (they'd make the file enormous).
 `sync.py` reads `sync_groups` from `enrichment.yaml` before running AppleScript.
 If the list is non-empty, AppleScript only iterates members of those groups — much faster than iterating all contacts. Duplicate contacts (in multiple groups) are deduplicated by UID within the AppleScript using a `seen` list.
 
+### Zoom system
+The family tree panel uses CSS `zoom` (not `transform: scale()`) on a `display: inline-block` wrapper in `App.jsx`.
+- CSS `zoom` affects layout (unlike `transform: scale()`), so `overflow: auto` on the parent scrolls correctly when zoomed in.
+- Natural content size is captured in `naturalSizeRef` via `handleReady`, which is called by `FamilyTreePanel` via `onReady` prop after data loads (using `requestAnimationFrame`).
+- `computeFit()` uses stored natural size to calculate `min(vpW/naturalW, vpH/naturalH, 1)`.
+- Auto-fit is triggered on group change: zoom resets to 1 first, then `onReady` fires after the async fetch and measures at scale 1.
+- `ZoomControls.jsx` is a floating `−` / `%` / `+` widget (bottom-right, `position: absolute`). The `%` button calls `handleFit`.
+
+### App settings
+`AppSettings` Pydantic model in `models.py` currently holds `default_group: Optional[str]`.
+`enrichment.py` exports `load_default_group(path)`.
+`/api/settings` endpoint in `main.py` returns `AppSettings`.
+`api.js` exports `getSettings()`.
+`App.jsx` fetches settings on startup alongside groups/contacts and applies `default_group` if set.
+
+### Mobile behaviour
+- Sidebar collapses by default on screens narrower than 1024px: `useState(() => window.innerWidth < 1024)`.
+- `LandscapeGuard.jsx` detects portrait orientation on mobile/tablet (width < 1024 OR height < 600) and overlays a "rotate device" message.
+- Uses `resize` + `orientationchange` events; no media query CSS is used.
+
+### Group selector
+The main content header uses a native `<select>` styled as a heading (appearance-none, bg-transparent) with a `▾` span as the visual indicator. Options are "All contacts" (value `""`) + all group names. Changing it calls `handleSelectGroup(name)` in `App.jsx`.
+
 ---
 
 ## Data flow on sync

--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ A personal relationship management web app that uses **Apple Contacts** as its s
 - Multi-generational family trees (couples + children, recursively)
 - Photos synced from the Apple Photos People album
 - Click-through detail panel (birthday, anniversary, family links, interests, notes)
+- Zoom in/out on the family tree view (auto-fits to screen on open)
+- Group selector dropdown in the main header — no need to use the sidebar
+- Configurable default group (app opens directly in your most-used group)
+- Landscape-mode enforcement on mobile with a "rotate device" overlay
 - Dark mode (follows system preference, with manual toggle)
-- Collapsible sidebar
+- Collapsible sidebar (collapsed by default on mobile/tablet)
 - Accessible on your home network from any device
 - Static HTML export for offline / on-the-go use (e.g. iCloud Drive)
 
@@ -115,6 +119,16 @@ All configuration lives in **`backend/data/enrichment.yaml`**.
 
 > **Note:** `enrichment.yaml` is listed in `.gitignore` because it contains personal data (group names, contact UIDs, notes). A clean template is provided at `backend/data/enrichment.yaml.sample`. Copy it to `enrichment.yaml` to get started — it will never be committed to git.
 
+### `default_group` — which group to open on startup
+
+```yaml
+default_group: "Familie Smit"
+```
+
+The app opens directly in this group instead of the "All contacts" view. Leave empty (or omit) to start with all contacts.
+
+---
+
 ### `sync_groups` — which groups to sync
 
 ```yaml
@@ -211,6 +225,7 @@ The backend exposes a small REST API (useful for debugging):
 | `GET /api/groups/{name}` | Family tree view for a group |
 | `GET /api/contacts` | All contacts (sorted by name) |
 | `GET /api/contacts/{uid}` | Single contact by UID |
+| `GET /api/settings` | App settings (e.g. `default_group`) |
 | `GET /api/diagnostics/unresolved` | Relationships that couldn't be auto-resolved |
 | `GET /api/docs` | Interactive API docs (Swagger UI) |
 
@@ -246,6 +261,8 @@ The backend exposes a small REST API (useful for debugging):
     │       ├── FamilyTreePanel.jsx
     │       ├── FamilyTreeNode.jsx
     │       ├── ContactDrawer.jsx
-    │       └── InitialsCircle.jsx
+    │       ├── InitialsCircle.jsx
+    │       ├── ZoomControls.jsx
+    │       └── LandscapeGuard.jsx
     └── dist/               # built frontend (auto-generated)
 ```

--- a/backend/data/enrichment.yaml.sample
+++ b/backend/data/enrichment.yaml.sample
@@ -7,6 +7,12 @@
 #   Or check /api/diagnostics/unresolved after your first sync for a list
 #   of relationships that couldn't be resolved automatically.
 
+# ─── Default group ────────────────────────────────────────────────────────────
+# The group the app opens with. Leave empty to show all contacts on startup.
+default_group: ""
+# Example:
+#   default_group: "Familie Smit"
+
 # ─── Sync filter ─────────────────────────────────────────────────────────────
 # List only the Apple Contacts group names you want to sync.
 # Leave empty ([]) to sync ALL contacts (slow if you have many).

--- a/backend/enrichment.py
+++ b/backend/enrichment.py
@@ -17,6 +17,12 @@ from parser import infer_relationships
 logger = logging.getLogger(__name__)
 
 
+def load_default_group(enrichment_path: Path) -> str | None:
+    """Return the configured default_group, or None."""
+    data = load_enrichment(enrichment_path)
+    return data.get("default_group") or None
+
+
 def load_enrichment(path: Path) -> dict:
     if not path.exists():
         return {}

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,9 +9,9 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from enrichment import apply_enrichment
+from enrichment import apply_enrichment, load_default_group
 from grouper import build_group_view, build_all_group_views
-from models import Contact, GroupSummary, GroupView, SyncResult, UnresolvedRelation
+from models import AppSettings, Contact, GroupSummary, GroupView, SyncResult, UnresolvedRelation
 from parser import parse_contacts
 from sync import sync_all
 
@@ -111,6 +111,12 @@ def get_contact(uid: str) -> Contact:
     if uid not in _contacts:
         raise HTTPException(status_code=404, detail="Contact not found")
     return _contacts[uid]
+
+
+@app.get("/api/settings", response_model=AppSettings)
+def get_settings() -> AppSettings:
+    """Returns app settings (e.g. default_group) from enrichment.yaml."""
+    return AppSettings(default_group=load_default_group(ENRICHMENT_FILE))
 
 
 @app.get("/api/diagnostics/unresolved", response_model=list[UnresolvedRelation])

--- a/backend/models.py
+++ b/backend/models.py
@@ -60,3 +60,7 @@ class SyncResult(BaseModel):
     contacts_count: int
     groups_count: int
     unresolved_count: int
+
+
+class AppSettings(BaseModel):
+    default_group: Optional[str] = None

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>My Contacts Overview</title>
   </head>
   <body>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,15 @@
-import { useEffect, useState, useCallback } from 'react'
-import { getAllContacts, getContactsMap, getGroups, syncContacts, IS_STATIC } from './api'
+import { useEffect, useState, useCallback, useRef } from 'react'
+import { getAllContacts, getContactsMap, getGroups, getSettings, syncContacts, IS_STATIC } from './api'
 import GroupSidebar from './components/GroupSidebar'
 import FamilyTreePanel from './components/FamilyTreePanel'
 import InitialsCircle from './components/InitialsCircle'
 import ContactDrawer from './components/ContactDrawer'
+import ZoomControls from './components/ZoomControls'
+import LandscapeGuard from './components/LandscapeGuard'
+
+const ZOOM_STEP = 0.15
+const ZOOM_MIN = 0.15
+const ZOOM_MAX = 2.0
 
 export default function App() {
   const [groups, setGroups] = useState([])
@@ -14,25 +20,68 @@ export default function App() {
   const [syncing, setSyncing] = useState(false)
   const [syncMsg, setSyncMsg] = useState(null)
   const [loading, setLoading] = useState(true)
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(
+    () => window.innerWidth < 1024
+  )
   const [isDark, setIsDark] = useState(
     () => window.matchMedia('(prefers-color-scheme: dark)').matches
   )
+  const [zoom, setZoom] = useState(1)
+
+  // Refs for zoom measurement
+  const viewportRef = useRef(null)   // the overflow-hidden clip container
+  const contentRef = useRef(null)    // the CSS-zoom wrapper around FamilyTreePanel
+  const naturalSizeRef = useRef({ w: 0, h: 0 })
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', isDark)
   }, [isDark])
 
+  // Compute fit-to-screen zoom from stored natural dimensions
+  const computeFit = useCallback(() => {
+    if (!viewportRef.current) return 1
+    const vp = viewportRef.current
+    const { w: naturalW, h: naturalH } = naturalSizeRef.current
+    if (naturalW <= 0 || naturalH <= 0) return 1
+    const vpW = vp.clientWidth - 48   // account for padding
+    const vpH = vp.clientHeight - 48
+    const fit = Math.min(vpW / naturalW, vpH / naturalH, 1)
+    return Math.max(ZOOM_MIN, fit)
+  }, [])
+
+  // Called by FamilyTreePanel after it finishes rendering — measure and auto-fit
+  const handleReady = useCallback(() => {
+    if (!contentRef.current) return
+    const ct = contentRef.current
+    // At this point zoom state is 1 (reset on group change), so offsetWidth = natural width
+    naturalSizeRef.current = { w: ct.offsetWidth, h: ct.offsetHeight }
+    setZoom(computeFit())
+  }, [computeFit])
+
+  const handleFit = useCallback(() => {
+    setZoom(computeFit())
+  }, [computeFit])
+
+  // Reset zoom when group changes so handleReady measures at scale 1
+  useEffect(() => {
+    setZoom(1)
+    naturalSizeRef.current = { w: 0, h: 0 }
+  }, [selectedGroup])
+
   const loadData = useCallback(async () => {
     try {
-      const [g, map, list] = await Promise.all([
+      const [g, map, list, settings] = await Promise.all([
         getGroups(),
         getContactsMap(),
         getAllContacts(),
+        getSettings(),
       ])
       setGroups(g)
       setContacts(map)
       setAllContacts(list)
+      if (settings?.default_group) {
+        setSelectedGroup(settings.default_group)
+      }
     } catch (e) {
       console.error('Failed to load data:', e)
     } finally {
@@ -58,6 +107,7 @@ export default function App() {
 
   const handleSelectContact = (uid) => setSelectedUid(uid)
   const handleCloseDrawer = () => setSelectedUid(null)
+  const handleSelectGroup = (name) => setSelectedGroup(name)
 
   const selectedContact = selectedUid ? contacts[selectedUid] : null
 
@@ -70,73 +120,106 @@ export default function App() {
   }
 
   return (
-    <div className="flex h-[100dvh] overflow-hidden bg-white dark:bg-gray-950 font-sans text-gray-900 dark:text-gray-100">
-      <GroupSidebar
-        groups={groups}
-        selectedGroup={selectedGroup}
-        onSelectGroup={setSelectedGroup}
-        onSync={handleSync}
-        syncing={syncing}
-        isStatic={IS_STATIC}
-        collapsed={sidebarCollapsed}
-        onToggleCollapse={() => setSidebarCollapsed(v => !v)}
-        isDark={isDark}
-        onToggleDark={() => setIsDark(v => !v)}
-      />
+    <LandscapeGuard>
+      <div className="flex h-[100dvh] overflow-hidden bg-white dark:bg-gray-950 font-sans text-gray-900 dark:text-gray-100" style={{ paddingLeft: 'env(safe-area-inset-left)', paddingRight: 'env(safe-area-inset-right)' }}>
+        <GroupSidebar
+          groups={groups}
+          selectedGroup={selectedGroup}
+          onSelectGroup={handleSelectGroup}
+          onSync={handleSync}
+          syncing={syncing}
+          isStatic={IS_STATIC}
+          collapsed={sidebarCollapsed}
+          onToggleCollapse={() => setSidebarCollapsed(v => !v)}
+          isDark={isDark}
+          onToggleDark={() => setIsDark(v => !v)}
+        />
 
-      <main className="flex-1 overflow-y-auto relative">
-        {/* Sync message banner */}
-        {syncMsg && (
-          <div className="sticky top-0 z-10 bg-green-50 dark:bg-green-900/30 border-b border-green-100 dark:border-green-800 px-6 py-2 text-sm text-green-700 dark:text-green-400 flex items-center justify-between">
-            <span>{syncMsg}</span>
-            <button onClick={() => setSyncMsg(null)} className="text-green-400 hover:text-green-600 ml-4">×</button>
-          </div>
-        )}
+        <main className="flex-1 overflow-hidden flex flex-col">
+          {/* Sync message banner */}
+          {syncMsg && (
+            <div className="shrink-0 bg-green-50 dark:bg-green-900/30 border-b border-green-100 dark:border-green-800 px-6 py-2 text-sm text-green-700 dark:text-green-400 flex items-center justify-between">
+              <span>{syncMsg}</span>
+              <button onClick={() => setSyncMsg(null)} className="text-green-400 hover:text-green-600 ml-4">×</button>
+            </div>
+          )}
 
-        {/* Group header */}
-        {selectedGroup && (
-          <div className="px-6 pt-5 pb-2 border-b border-gray-100 dark:border-gray-800">
-            <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100">{selectedGroup}</h2>
+          {/* Header: group selector dropdown */}
+          <div className="shrink-0 px-6 pt-5 pb-3 border-b border-gray-100 dark:border-gray-800">
+            <div className="relative inline-flex items-center gap-1">
+              <select
+                value={selectedGroup ?? ''}
+                onChange={e => handleSelectGroup(e.target.value || null)}
+                className="text-xl font-semibold text-gray-800 dark:text-gray-100 bg-transparent border-none outline-none cursor-pointer appearance-none pr-5 max-w-xs"
+              >
+                <option value="">All contacts</option>
+                {groups.map(g => (
+                  <option key={g.name} value={g.name}>{g.name}</option>
+                ))}
+              </select>
+              <span className="pointer-events-none text-gray-400 dark:text-gray-500 text-sm -ml-4">▾</span>
+            </div>
             <p className="text-sm text-gray-400 dark:text-gray-500 mt-0.5">
-              {groups.find(g => g.name === selectedGroup)?.count ?? 0} contacts
+              {selectedGroup
+                ? `${groups.find(g => g.name === selectedGroup)?.count ?? 0} contacts`
+                : `${allContacts.length} contacts`}
             </p>
           </div>
-        )}
 
-        {/* Group tree view */}
-        {selectedGroup ? (
-          <FamilyTreePanel
-            groupName={selectedGroup}
+          {/* Content area */}
+          <div ref={viewportRef} className="flex-1 overflow-hidden relative">
+            {selectedGroup ? (
+              <>
+                {/* Scaled family tree content */}
+                <div className="absolute inset-0 overflow-auto p-6">
+                  <div
+                    ref={contentRef}
+                    style={{ zoom, display: 'inline-block', minWidth: 'max-content' }}
+                  >
+                    <FamilyTreePanel
+                      groupName={selectedGroup}
+                      contacts={contacts}
+                      onSelectContact={handleSelectContact}
+                      onReady={handleReady}
+                    />
+                  </div>
+                </div>
+
+                {/* Zoom controls (floating, bottom-right) */}
+                <ZoomControls
+                  zoom={zoom}
+                  onZoomIn={() => setZoom(z => Math.min(ZOOM_MAX, +(z + ZOOM_STEP).toFixed(2)))}
+                  onZoomOut={() => setZoom(z => Math.max(ZOOM_MIN, +(z - ZOOM_STEP).toFixed(2)))}
+                  onFit={handleFit}
+                />
+              </>
+            ) : (
+              /* All contacts flat grid */
+              <div className="overflow-y-auto h-full p-6">
+                <div className="flex flex-wrap gap-5">
+                  {allContacts.map(c => (
+                    <InitialsCircle
+                      key={c.uid}
+                      contact={c}
+                      onSelect={handleSelectContact}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </main>
+
+        {/* Detail drawer */}
+        {selectedContact && (
+          <ContactDrawer
+            contact={selectedContact}
             contacts={contacts}
+            onClose={handleCloseDrawer}
             onSelectContact={handleSelectContact}
           />
-        ) : (
-          /* All contacts flat grid */
-          <div className="p-6">
-            <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-1">All contacts</h2>
-            <p className="text-sm text-gray-400 dark:text-gray-500 mb-5">{allContacts.length} people</p>
-            <div className="flex flex-wrap gap-5">
-              {allContacts.map(c => (
-                <InitialsCircle
-                  key={c.uid}
-                  contact={c}
-                  onSelect={handleSelectContact}
-                />
-              ))}
-            </div>
-          </div>
         )}
-      </main>
-
-      {/* Detail drawer */}
-      {selectedContact && (
-        <ContactDrawer
-          contact={selectedContact}
-          contacts={contacts}
-          onClose={handleCloseDrawer}
-          onSelectContact={handleSelectContact}
-        />
-      )}
-    </div>
+      </div>
+    </LandscapeGuard>
   )
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -44,4 +44,11 @@ export async function syncContacts() {
   return res.json()
 }
 
+export async function getSettings() {
+  if (isStatic) return staticData().settings ?? {}
+  const res = await fetch('/api/settings')
+  if (!res.ok) throw new Error('Failed to fetch settings')
+  return res.json()
+}
+
 export const IS_STATIC = isStatic

--- a/frontend/src/components/FamilyTreePanel.jsx
+++ b/frontend/src/components/FamilyTreePanel.jsx
@@ -3,7 +3,7 @@ import { getGroupView } from '../api'
 import FamilyTreeNode from './FamilyTreeNode'
 import InitialsCircle from './InitialsCircle'
 
-export default function FamilyTreePanel({ groupName, contacts, onSelectContact }) {
+export default function FamilyTreePanel({ groupName, contacts, onSelectContact, onReady }) {
   const [view, setView] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
@@ -12,11 +12,19 @@ export default function FamilyTreePanel({ groupName, contacts, onSelectContact }
     if (!groupName) return
     setLoading(true)
     setError(null)
+    setView(null)
     getGroupView(groupName)
       .then(setView)
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
   }, [groupName])
+
+  // Notify parent once the view has rendered so it can measure and auto-fit
+  useEffect(() => {
+    if (view) {
+      requestAnimationFrame(() => onReady?.())
+    }
+  }, [view, onReady])
 
   if (!groupName) return null
 
@@ -49,18 +57,17 @@ export default function FamilyTreePanel({ groupName, contacts, onSelectContact }
   }
 
   return (
-    <div className="p-6 overflow-x-auto">
+    <div className="p-6">
       <div className="flex flex-wrap gap-10 content-start items-start">
-      {/* Family trees */}
-      {view.trees?.map((tree, i) => (
-        <FamilyTreeNode
-          key={i}
-          node={tree}
-          contacts={contacts}
-          onSelect={onSelectContact}
-        />
-      ))}
-
+        {/* Family trees */}
+        {view.trees?.map((tree, i) => (
+          <FamilyTreeNode
+            key={i}
+            node={tree}
+            contacts={contacts}
+            onSelect={onSelectContact}
+          />
+        ))}
       </div>
 
       {/* Standalone contacts (not in any family structure) */}

--- a/frontend/src/components/LandscapeGuard.jsx
+++ b/frontend/src/components/LandscapeGuard.jsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * On narrow/mobile screens, shows a "rotate device" overlay when portrait.
+ * On tablets and desktops the overlay is never shown.
+ */
+export default function LandscapeGuard({ children }) {
+  const [showOverlay, setShowOverlay] = useState(false)
+
+  useEffect(() => {
+    const check = () => {
+      // Only enforce on devices where landscape matters (narrow or short screens)
+      const isMobile = window.innerWidth < 1024 || window.innerHeight < 600
+      const isPortrait = window.matchMedia('(orientation: portrait)').matches
+      setShowOverlay(isMobile && isPortrait)
+    }
+    check()
+    window.addEventListener('resize', check)
+    window.addEventListener('orientationchange', check)
+    return () => {
+      window.removeEventListener('resize', check)
+      window.removeEventListener('orientationchange', check)
+    }
+  }, [])
+
+  return (
+    <>
+      {children}
+      {showOverlay && (
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-gray-950/95 text-white select-none">
+          <div className="text-6xl mb-6 animate-pulse">↻</div>
+          <p className="text-lg font-semibold">Rotate your device</p>
+          <p className="text-sm text-gray-400 mt-2">This app works best in landscape mode</p>
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/ZoomControls.jsx
+++ b/frontend/src/components/ZoomControls.jsx
@@ -1,0 +1,30 @@
+/**
+ * Floating zoom controls overlay — shown over the family tree panel.
+ */
+export default function ZoomControls({ zoom, onZoomIn, onZoomOut, onFit }) {
+  return (
+    <div className="absolute bottom-4 right-4 z-10 flex items-center gap-0.5 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-md px-1 py-1">
+      <button
+        onClick={onZoomOut}
+        className="w-7 h-7 flex items-center justify-center text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded text-base font-medium transition-colors"
+        title="Zoom out"
+      >
+        −
+      </button>
+      <button
+        onClick={onFit}
+        className="px-2 h-7 flex items-center text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors font-mono tabular-nums min-w-[44px] justify-center"
+        title="Fit to screen"
+      >
+        {Math.round(zoom * 100)}%
+      </button>
+      <button
+        onClick={onZoomIn}
+        className="w-7 h-7 flex items-center justify-center text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded text-base font-medium transition-colors"
+        title="Zoom in"
+      >
+        +
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **ZoomControls**: floating `−` / `%` / `+` widget for pinch-free zoom on mobile; `%` triggers fit-to-screen
- **LandscapeGuard**: overlay prompting rotation on narrow/short screens in portrait mode
- **Zoom system**: uses CSS `zoom` (not `transform: scale()`) so scrolling works correctly when zoomed in; auto-fits on group change
- **App settings**: `/api/settings` endpoint returning `default_group` from `enrichment.yaml`
- **Sidebar**: collapses by default on screens narrower than 1024px
- **Group selector**: native `<select>` styled as a heading in the content header
- **iOS safe-area fix**: `viewport-fit=cover` + `env(safe-area-inset-left/right)` padding eliminates white bars in landscape mode

## Test plan

- [ ] Open app on mobile in landscape — no white bars on left/right edges
- [x] Open app on mobile in portrait — rotate-device overlay appears
- [x] Rotate to landscape — overlay disappears, tree is visible
- [x] Select a family group — tree auto-fits to screen
- [x] Tap `+` / `−` to zoom in/out; tap `%` to re-fit
- [x] On desktop (> 1024px) — sidebar visible by default, no landscape guard shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)