### PR TITLE
Fix Pydantic deprecation: replace .dict() with .model_dump()

### DIFF
--- a/export.py
+++ b/export.py
@@ -51,9 +51,9 @@ def build_app_data(contacts: dict, groups_data: dict, enrichment_path: Path) -> 
     )
 
     return {
-        "contacts": {uid: c.dict() for uid, c in contacts.items()},
+        "contacts": {uid: c.model_dump() for uid, c in contacts.items()},
         "groups": groups_list,
-        "groupViews": {name: view.dict() for name, view in group_views.items()},
+        "groupViews": {name: view.model_dump() for name, view in group_views.items()},
         "settings": {"default_group": default_group},
     }
 


### PR DESCRIPTION
## Summary
- Replaces 2 deprecated `.dict()` calls with `.model_dump()` in `export.py` (lines 54 and 56)
- These were the only occurrences of deprecated Pydantic v1 APIs in the codebase

Closes #21

## Test plan
- [ ] Run `python3 export.py --skip-sync` and confirm no `PydanticDeprecatedSince20` warnings appear in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)