### PR TITLE
Fix FamilyNavigator root view to show each family separately

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "input=$(cat); echo \"$input\" | python3 -c \"import sys,json; d=json.load(sys.stdin); exit(0 if 'frontend/src/' in d.get('tool_input',{}).get('file_path','') else 1)\" && npm --prefix /Users/henkjanborghuis/github/fafo/frontend run build; exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/src/components/FamilyNavigator.jsx
+++ b/frontend/src/components/FamilyNavigator.jsx
@@ -48,12 +48,8 @@ export default function FamilyNavigator({ groupName, contacts, onSelect }) {
     )
   }
 
-  // Root level mode: multiple root trees with no common ancestor — show them all
+  // Root level mode: multiple root trees with no common ancestor — show each family separately
   if (!focalUid) {
-    const rootUids = groupView.trees.flatMap(t => t.couple)
-    const childUids = [...new Set(
-      rootUids.flatMap(uid => contacts[uid]?.children_uids ?? [])
-    )]
     return (
       <div className="flex flex-col h-full overflow-hidden">
         <div className="shrink-0 px-4 py-2 border-b border-gray-100 dark:border-gray-800 flex items-center">
@@ -66,24 +62,32 @@ export default function FamilyNavigator({ groupName, contacts, onSelect }) {
         </div>
         <div className="flex-1 overflow-y-auto">
           <div className="flex flex-col p-4">
-            <div className="py-4">
-              <div className="text-xs font-medium text-blue-500 dark:text-blue-400 uppercase tracking-wide mb-2">
-                Viewing
-              </div>
-              <div className="flex flex-wrap gap-3 px-3 py-2.5 rounded-2xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 shadow-sm">
-                {rootUids.map(uid => contacts[uid] && (
-                  <InitialsCircle key={uid} contact={contacts[uid]} onSelect={navigateTo} size="md" />
-                ))}
-              </div>
-            </div>
-            {childUids.length > 0 && (
-              <NavigatorRow
-                label="Children"
-                uids={childUids}
-                contacts={contacts}
-                onTap={navigateTo}
-              />
-            )}
+            {groupView.trees.map((tree, idx) => {
+              const rootSet = new Set(tree.couple)
+              const childUids = tree.children.map(child =>
+                child.couple.find(uid => contacts[uid]?.parent_uids?.some(p => rootSet.has(p)))
+                ?? child.couple[0]
+              )
+              return (
+                <div key={idx} className={idx > 0 ? 'border-t border-gray-100 dark:border-gray-800' : ''}>
+                  <div className="py-4">
+                    <div className="flex flex-wrap gap-3 px-3 py-2.5 rounded-2xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 shadow-sm">
+                      {tree.couple.map(uid => contacts[uid] && (
+                        <InitialsCircle key={uid} contact={contacts[uid]} onSelect={navigateTo} size="md" />
+                      ))}
+                    </div>
+                  </div>
+                  {childUids.length > 0 && (
+                    <NavigatorRow
+                      label="Children"
+                      uids={childUids}
+                      contacts={contacts}
+                      onTap={navigateTo}
+                    />
+                  )}
+                </div>
+              )
+            })}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Fixed root-level mode in `FamilyNavigator` to render each family tree independently, with its own couple row and children row, instead of merging all root couples into one flat list
- Added `.claude/settings.json` with a PostToolUse hook that auto-builds the frontend whenever a frontend source file is edited

## Test plan

- [x] Open a group that has multiple root families (no shared ancestor)
- [x] Verify each family shows as a separate section with its own couple pill and children row
- [x] Verify navigating into a specific person still works as before