### PR TITLE
Add reason field to unresolved relationship diagnostics

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -49,8 +49,11 @@ def _load_contacts() -> None:
     if groups_path.exists():
         groups_data = json.loads(groups_path.read_text())
 
+    all_names_path = DATA_DIR / "all_names.json"
+    all_names = set(json.loads(all_names_path.read_text())) if all_names_path.exists() else None
+
     vcf_text = vcf_path.read_text(encoding="utf-8")
-    _contacts, _unresolved = parse_contacts(vcf_text, groups_data)
+    _contacts, _unresolved = parse_contacts(vcf_text, groups_data, all_names)
     _contacts = apply_enrichment(_contacts, ENRICHMENT_FILE)
     logger.info(f"Loaded {len(_contacts)} contacts")
 
@@ -66,14 +69,14 @@ def sync_contacts() -> SyncResult:
     global _contacts, _unresolved
     import json
 
-    vcf_text, groups_data = sync_all()
+    vcf_text, groups_data, all_names = sync_all()
     # Persist groups for future loads
     DATA_DIR.mkdir(exist_ok=True)
     (DATA_DIR / "groups.json").write_text(
         json.dumps(groups_data, ensure_ascii=False), encoding="utf-8"
     )
 
-    _contacts, _unresolved = parse_contacts(vcf_text, groups_data)
+    _contacts, _unresolved = parse_contacts(vcf_text, groups_data, all_names)
     _contacts = apply_enrichment(_contacts, ENRICHMENT_FILE)
 
     return SyncResult(

--- a/backend/models.py
+++ b/backend/models.py
@@ -56,6 +56,7 @@ class UnresolvedRelation(BaseModel):
     related_name: str
     label: str
     candidates: list[str] = []  # UIDs of ambiguous matches
+    reason: str = "not_found"   # "not_found" | "out_of_scope" | "ambiguous"
 
 
 class SyncResult(BaseModel):

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -201,7 +201,10 @@ def _apply_relation(contacts: dict[str, Contact], from_uid: str, to_uid: str, la
             tgt.sibling_uids.append(from_uid)
 
 
-def _resolve_relationships(contacts: dict[str, Contact]) -> list[dict]:
+def _resolve_relationships(
+    contacts: dict[str, Contact],
+    all_contact_names: set[str] | None = None,
+) -> list[dict]:
     """
     Attempt to resolve raw Related Names text → contact UIDs.
     Returns list of unresolved / ambiguous relations for diagnostics.
@@ -245,6 +248,12 @@ def _resolve_relationships(contacts: dict[str, Contact]) -> list[dict]:
                 if len(fname_candidates) == 1 and not candidates:
                     _apply_relation(contacts, uid, fname_candidates[0], label)
                 else:
+                    if candidates or fname_candidates:
+                        reason = "ambiguous"
+                    elif all_contact_names and target_name in all_contact_names:
+                        reason = "out_of_scope"
+                    else:
+                        reason = "not_found"
                     unresolved.append(
                         {
                             "contact_uid": uid,
@@ -252,6 +261,7 @@ def _resolve_relationships(contacts: dict[str, Contact]) -> list[dict]:
                             "related_name": rel.name,
                             "label": label,
                             "candidates": candidates or fname_candidates,
+                            "reason": reason,
                         }
                     )
 
@@ -320,7 +330,9 @@ PHOTOS_DIR = Path(__file__).parent / "data" / "photos"
 
 
 def parse_contacts(
-    vcf_text: str, groups_data: dict[str, list[str]]
+    vcf_text: str,
+    groups_data: dict[str, list[str]],
+    all_contact_names: set[str] | None = None,
 ) -> tuple[dict[str, Contact], list[dict]]:
     """
     Parse vCards, assign groups, resolve relationships.
@@ -347,7 +359,7 @@ def parse_contacts(
             if uid in contacts and group_name not in contacts[uid].groups:
                 contacts[uid].groups.append(group_name)
 
-    unresolved = _resolve_relationships(contacts)
+    unresolved = _resolve_relationships(contacts, all_contact_names)
 
     logger.info(
         f"Parsed {len(contacts)} contacts, {len(unresolved)} unresolved relations"

--- a/backend/sync.py
+++ b/backend/sync.py
@@ -149,9 +149,30 @@ def export_groups(group_names: list[str] | None = None) -> dict[str, list[str]]:
     return groups
 
 
-def sync_all() -> tuple[str, dict[str, list[str]]]:
-    """Run both exports and return (vcf_text, groups_dict)."""
+def export_all_names() -> set[str]:
+    """Return display names of ALL contacts in Apple Contacts (not filtered by group)."""
+    script = """
+tell application "Contacts"
+    set output to ""
+    repeat with p in every person
+        set n to name of p
+        if n is not missing value then
+            set output to output & n & "\n"
+        end if
+    end repeat
+    output
+end tell
+"""
+    raw = _run_applescript(script)
+    return {line.strip().lower() for line in raw.splitlines() if line.strip()}
+
+
+def sync_all() -> tuple[str, dict[str, list[str]], set[str]]:
+    """Run all exports and return (vcf_text, groups_dict, all_contact_names)."""
+    import json
     group_names = _load_sync_groups()
     vcf_text = export_vcards(group_names)
     groups = export_groups(group_names)
-    return vcf_text, groups
+    all_names = export_all_names()
+    (DATA_DIR / "all_names.json").write_text(json.dumps(sorted(all_names)))
+    return vcf_text, groups, all_names


### PR DESCRIPTION
## Summary

- Adds a `reason` field to the `UnresolvedRelation` model and `/api/diagnostics/unresolved` response
- Three possible values: `out_of_scope` (contact exists in Apple Contacts but not in synced groups), `not_found` (name doesn't exist anywhere), `ambiguous` (multiple candidates matched)
- Adds `export_all_names()` in `sync.py` — a lightweight name-only AppleScript over all contacts, result persisted to `data/all_names.json`
- Falls back gracefully to `not_found` if `all_names.json` doesn't exist yet (first run before a sync)

## Test plan

- [x] Click **Sync Contacts** and verify `backend/data/all_names.json` is created
- [x] `curl http://localhost:8000/api/diagnostics/unresolved` — Wim Borghuis's siblings should show `"reason": "out_of_scope"`
- [x] A deliberately misspelled name in `enrichment.yaml` relationships should show `"reason": "not_found"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)