### PR TITLE
Fix export.py crash: sync_all returns 3-tuple

### DIFF
--- a/export.py
+++ b/export.py
@@ -201,7 +201,7 @@ def main():
     else:
         from sync import sync_all
         logger.info("Syncing from Apple Contacts...")
-        vcf_text, groups_data = sync_all()
+        vcf_text, groups_data, _ = sync_all()
         # Persist for future --skip-sync runs
         groups_path = BACKEND / "data" / "groups.json"
         groups_path.parent.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary

- `sync_all()` was updated to return a 3-tuple `(vcf_text, groups_dict, all_contact_names)` but `export.py` still unpacked only 2 values, causing a crash on every export run
- Fix: use `vcf_text, groups_data, _ = sync_all()` to discard the unused third value

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)