### PR TITLE
Add all_names.json to .gitignore to prevent PII leakage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Never commit them. Copy enrichment.yaml.sample → enrichment.yaml to get started.
 backend/data/contacts.vcf
 backend/data/groups.json
+backend/data/all_names.json
 backend/data/photos/
 backend/data/enrichment.yaml
 


### PR DESCRIPTION
## Summary

- `backend/data/all_names.json` contains real contact names (PII) and was missing from the personal data exclusions in `.gitignore`
- Added it alongside the other generated data files already excluded (`contacts.vcf`, `groups.json`, `photos/`, `enrichment.yaml`)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)