### PR TITLE
Ignore .claude/worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ venv/
 
 # ── Test / dev tooling ───────────────────────────────────────────────────────
 .playwright-mcp/
+.claude/worktrees/


### PR DESCRIPTION
The Claude Code subagent worktrees plugin creates `.claude/worktrees/` locally to host isolated worktrees. It should never be committed.

## Test plan
- [x] `git status` no longer reports `.claude/worktrees/` as untracked.